### PR TITLE
Enable DNS Query Logging for Route 53 Hosted Zones with KMS Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Building on use case 2, this implementation shows how to:
 
 For details please visit - [automate-amazon-route-53-hosted-zone-acm-and-load-balancer-provisioning-with-terraform-and-github-actions.](http://skundunotes.com/2025/03/25/automate-amazon-route-53-hosted-zone-acm-and-load-balancer-provisioning-with-terraform-and-github-actions/)
 
+## Use Case 4: Enable Domain Name System (DNS) query logging for Amazon Route 53 hosted zones using Terraform
+**🔔 Attention:** The code for this specific use case is located in the [`add-dns-query-r53`](https://github.com/kunduso/add-aws-elb-ec2-private-subnet-terraform/tree/add-dns-query-r53) branch. Please refer to this branch instead of the default `main` branch. **🔔**
+![Image](https://skdevops.files.wordpress.com/2025/04/114-image-0.png)
+Building on use case 3, this use case demonstrates how to implement DNS query logging for Route 53 hosted zones to enhance security monitoring and operational visibility. DNS query logging provides detailed information about DNS queries received by Route 53, helping teams detect security threats, troubleshoot issues, and maintain compliance requirements.
+
+The solution includes:
+- Amazon Route 53 query logging configuration
+- Amazon CloudWatch log group with KMS encryption
+- KMS key with appropriate key policy
+
+### Regional Consideration
+While most AWS resources in this project are provisioned in `us-east-2`, the CloudWatch log group and KMS key for DNS query logging must be created in `us-east-1`. This is a mandatory AWS requirement. To handle this, we use a separate AWS provider configuration specifically for these components.
+
+For details please visit - [enable-domain-name-system-dns-query-logging-for-amazon-route-53-hosted-zones-using-terraform.](https://skundunotes.com/2025/04/09/enable-domain-name-system-dns-query-logging-for-amazon-route-53-hosted-zones-using-terraform/)
+
 ## Prerequisites
 For this code to function without errors, please create an OpenID connect identity provider in Amazon Identity and Access Management that has a trust relationship with this GitHub repository. You can read about it [here](https://skundunotes.com/2023/02/28/securely-integrate-aws-credentials-with-github-actions-using-openid-connect/) to get a detailed explanation with steps.
 <br />Store the `ARN` of the `IAM Role` as a GitHub secret which is referred in the [`terraform.yml`](https://github.com/kunduso/add-aws-elb-ec2-private-subnet-terraform/blob/4144f6ea8f2599658a760f382241594aa001b433/.github/workflows/terraform.yml#L31-L36) file.

--- a/acm.tf
+++ b/acm.tf
@@ -1,5 +1,4 @@
-
-
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate
 resource "aws_acm_certificate" "main" {
   domain_name       = var.domain_name
   validation_method = "DNS"
@@ -9,6 +8,7 @@ resource "aws_acm_certificate" "main" {
   }
 }
 
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation
 resource "aws_acm_certificate_validation" "main" {
   certificate_arn         = aws_acm_certificate.main.arn
   validation_record_fqdns = [for record in aws_route53_record.acm_validation : record.fqdn]

--- a/compute.tf
+++ b/compute.tf
@@ -11,6 +11,7 @@ data "aws_ami" "amazon_ami" {
   most_recent = true
   owners      = ["amazon"]
 }
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
 resource "aws_instance" "app-server" {
   count                  = length(var.subnet_cidr_private)
   instance_type          = var.instance_type

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -78,6 +78,7 @@ resource "aws_s3_bucket" "artifacts" {
   #serverside encryption resource is created below: 
   #resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt_bucket" {}
 }
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block
 resource "aws_s3_bucket_public_access_block" "artifacts" {
   bucket                  = aws_s3_bucket.artifacts.id
   block_public_acls       = true
@@ -86,6 +87,7 @@ resource "aws_s3_bucket_public_access_block" "artifacts" {
   ignore_public_acls      = true
 }
 
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration
 resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt_bucket" {
   bucket = aws_s3_bucket.artifacts.bucket
   rule {
@@ -95,6 +97,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt_bucket" {
   }
 }
 #https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy
 resource "aws_s3_bucket_policy" "alb_logs" {
   bucket = aws_s3_bucket.artifacts.id
 

--- a/loadbalancer.tf
+++ b/loadbalancer.tf
@@ -40,6 +40,7 @@ resource "aws_lb_listener" "front_end" {
 
   }
 }
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.front.arn
   port              = "443"

--- a/provider.tf
+++ b/provider.tf
@@ -17,7 +17,7 @@ provider "aws" {
     }
   }
 }
-# Provider for us-east-1 (required for DNSSEC KMS key)
+# Provider for us-east-1 (required for DNS query logging)
 provider "aws" {
   alias      = "us-east-1"
   region     = "us-east-1"

--- a/provider.tf
+++ b/provider.tf
@@ -17,15 +17,3 @@ provider "aws" {
     }
   }
 }
-# Provider for us-east-1 (required for DNSSEC KMS key)
-provider "aws" {
-  alias      = "us-east-1"
-  region     = "us-east-1"
-  access_key = var.access_key
-  secret_key = var.secret_key
-  default_tags {
-    tags = {
-      Source = "https://github.com/kunduso/add-aws-elb-ec2-private-subnet-terraform"
-    }
-  }
-}

--- a/provider.tf
+++ b/provider.tf
@@ -17,3 +17,15 @@ provider "aws" {
     }
   }
 }
+# Provider for us-east-1 (required for DNSSEC KMS key)
+provider "aws" {
+  alias      = "us-east-1"
+  region     = "us-east-1"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  default_tags {
+    tags = {
+      Source = "https://github.com/kunduso/add-aws-elb-ec2-private-subnet-terraform"
+    }
+  }
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,10 +1,10 @@
-
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone
 resource "aws_route53_zone" "main" {
   name = var.domain_name
   #checkov:skip=CKV2_AWS_39: Domain Name System (DNS) query logging is not enabled for Amazon Route 53 hosted zones
   #This check is disabled since this use case is for non-prod environment.
 }
-
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record
 resource "aws_route53_record" "alb" {
   zone_id = aws_route53_zone.main.zone_id
   name    = var.domain_name
@@ -16,7 +16,7 @@ resource "aws_route53_record" "alb" {
     evaluate_target_health = true
   }
 }
-
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record
 resource "aws_route53_record" "acm_validation" {
   for_each = {
     for dvo in aws_acm_certificate.main.domain_validation_options : dvo.domain_name => {

--- a/route53.tf
+++ b/route53.tf
@@ -31,33 +31,8 @@ resource "aws_route53_record" "acm_validation" {
   type            = each.value.type
   zone_id         = aws_route53_zone.main.zone_id
 }
-
-data "aws_iam_policy_document" "route53-query-logging-policy" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = ["arn:aws:logs:*:*:log-group:/aws/route53/*"]
-
-    principals {
-      identifiers = ["route53.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_cloudwatch_log_resource_policy" "route53-query-logging-policy" {
-  provider = aws.us-east-1
-
-  policy_document = data.aws_iam_policy_document.route53-query-logging-policy.json
-  policy_name     = "route53-query-logging-policy"
-}
-
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log
 resource "aws_route53_query_log" "dns_query" {
-  depends_on = [aws_cloudwatch_log_resource_policy.route53-query-logging-policy]
-
   cloudwatch_log_group_arn = aws_cloudwatch_log_group.dns_query_log_group.arn
   zone_id                  = aws_route53_zone.main.zone_id
 }

--- a/route53_dns_query.tf
+++ b/route53_dns_query.tf
@@ -1,7 +1,7 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region
 data "aws_region" "us-east-1" {
   provider = aws.us-east-1
 }
-
 locals {
   dns_query_log                = "/aws/route53/${var.name}/dns-query-logs"
   principal_logs_us-east-1_arn = "logs.${data.aws_region.us-east-1.name}.amazonaws.com"

--- a/route53_dns_query.tf
+++ b/route53_dns_query.tf
@@ -1,0 +1,67 @@
+data "aws_region" "us-east-1" {
+  provider = aws.us-east-1
+}
+
+locals {
+  dns_query_log                = "/aws/route53/${var.name}/dns-query-logs"
+  principal_logs_us-east-1_arn = "logs.${data.aws_region.us-east-1.name}.amazonaws.com"
+  dns_query_log_group_arn      = "arn:aws:logs:${data.aws_region.us-east-1.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.dns_query_log}"
+}
+# Create CloudWatch log group to store DNS query logs
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
+resource "aws_cloudwatch_log_group" "dns_query_log_group" {
+  provider          = aws.us-east-1
+  name              = local.dns_query_log
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.dns_query_log.arn
+}
+# Create a KMS Key to encrypt the CloudWatch logs
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "dns_query_log" {
+  provider                = aws.us-east-1
+  description             = "KMS key to encrypt DNS query logs."
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = local.principal_root_arn
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow CloudWatch Logs"
+        Effect = "Allow"
+        Principal = {
+          Service = local.principal_logs_us-east-1_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" : "${local.dns_query_log_group_arn}*"
+          }
+        }
+      }
+    ]
+  })
+}
+# Create an alias for the KMS key
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "dns_query_log" {
+  provider      = aws.us-east-1
+  name          = "alias/${var.name}-dns-query-cloudwatch-logs"
+  target_key_id = aws_kms_key.dns_query_log.key_id
+}

--- a/securitygroup.tf
+++ b/securitygroup.tf
@@ -47,6 +47,7 @@ resource "aws_security_group_rule" "ingress_load_balancer" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.lb_security_group.id
 }
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
 resource "aws_security_group_rule" "ingress_from_ec2" {
   description              = "Allow traffic into the load balancer from the EC2 instance."
   type                     = "ingress"


### PR DESCRIPTION
This PR implements encrypted DNS query logging for Route 53 hosted zones to enhance security monitoring and compliance requirements, and closes #71 .

Key Changes:
- Enabled Route 53 query logging for hosted zones
- Created CloudWatch log group for DNS query logs in us-east-1 region (AWS requirement for Route 53 query logs)
- Implemented KMS encryption for DNS query logs
  - Created KMS key with specific key policy
  - Configured CloudWatch log group with KMS encryption
- Set up log retention policies

Security Benefits:
- Improved visibility into DNS traffic patterns
- Enhanced ability to detect suspicious DNS activities
- Better audit trail for compliance requirements
- Enables DNS-based threat detection
- Encrypted log data at rest using KMS

Documentation:
- Updated infrastructure documentation
- Added logging and encryption configuration details
- Documented regional requirements for Route 53 query logging

Testing:
- Verified log group creation in us-east-1
- Confirmed DNS queries are being logged
- Validated KMS encryption configuration
- Tested with Terraform plan
